### PR TITLE
Reorder package.json exports to match webpack expectations

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "main": "dist/geo-viewport.cjs",
   "exports": {
     "require": "./dist/geo-viewport.cjs",
-    "default": "./dist/geo-viewport.es.mjs",
-    "types": "./dist/index.d.ts"
+    "types": "./dist/index.d.ts",
+    "default": "./dist/geo-viewport.es.mjs"
   },
   "author": "Tom MacWright",
   "bugs": {


### PR DESCRIPTION
From https://webpack.js.org/guides/package-exports/,
> The last condition in the object might be the special "default"
> condition, which is always matched.

This is enforced starting in enhanced-resolve v5 (from webpack).

The specific code in question can be found at https://github.com/webpack/enhanced-resolve/blob/a998c7d218b7a9ec2461fc4fddd1ad5dd7687485/lib/util/entrypoints.js#L474 .

Rather unfortunately, webpack does not throw a useful error (`Module not found: Error: Default condition should be last one`). For those who find this PR looking for what is causing that error, modify the local copy of `entrypoints.js` from `enhanced-resolve` to log out anything that you think might be useful. I used `console.log(mapping);` to find something to run `grep` for.